### PR TITLE
[fix] Make submodules use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "cev_planner"]
 	path = cev_planner
-	url = git@github.com:cornellev/cev_planner.git
+	url = https://github.com/cornellev/cev_planner.git
 [submodule "tmp/matplotlib-cpp"]
 	path = tmp/matplotlib-cpp
 	url = https://github.com/lava/matplotlib-cpp.git


### PR DESCRIPTION
Since most of the submodules in `rc-brain` use HTTPS, I updated this to be through HTTPS too. I understand that this might break some workflows, so maybe we have to think about it. HTTPS works for me, but Sid said it doesn't work for him?